### PR TITLE
Change to update process

### DIFF
--- a/src/pages/guides/gateway/create-tenant
+++ b/src/pages/guides/gateway/create-tenant
@@ -80,13 +80,13 @@ After creating a tenant, you should be able to access the GraphQL endpoint by en
 
 ## Update an existing tenant
 
-If you make any changes to your mesh file, such as adding [transforms], you must publish them before the changes will be reflected in your gateway. The following command will update the `tenantId` with the settings specified in the `mesh1.json` file.
+If you make any changes to your mesh file, such as adding [transforms], you must publish them before the changes will be reflected in your gateway. The following command will update the `tenantId` with the settings specified in the `update-mesh.json` file.
 
 ```bash
-aio commerce-gateway:tenant:update tenantid mesh1.json
+aio commerce-gateway:tenant:update tenantid update-mesh.json
 ```
 
-When updating a tenant, do not include a tenantId in your mesh `JSON` file. Compare the following example to the previous [Creating a tenant](#creating_a_tenant) example.
+When updating a tenant, do not include a tenantId in your mesh `JSON` file. Compare the following example to the previous [Creating a tenant](#creating_a_tenant) example on this page and note the absence of the `tenantId`.
 
     ```json
     {


### PR DESCRIPTION
## Purpose of this pull request

Dev made changes to the update process, because the tenantid is in the CLI command, they don't want the tenantid in the `mesh.json` file when its used for an update. 

No specific jira ticket. 