### PR TITLE
Remove events:registration commands

### DIFF
--- a/src/pages/events/commands.md
+++ b/src/pages/events/commands.md
@@ -12,11 +12,12 @@ Adobe Commerce provides the following commands to configure and process events:
 *  Enable integration between Commerce and Adobe I/O events
    *  [events:create-event-provider](#create-an-event-provider)  
 
-*  Manage events subscriptions
+*  Manage event subscriptions
    *  [events:subscribe](#subscribe-to-a-commerce-event)
    *  [events:metadata:populate](#create-event-metadata-in-adobe-io)
    *  [events:unsubscribe](#unsubscribe-from-a-commerce-event)
    *  [events:list](#list-subscribed-commerce-events)
+   *  [events:info](#return-event-details)
 
 *  Manage registrations
    *  [events:registration:create](#create-a-registration)
@@ -165,6 +166,28 @@ bin/magento events:list
 ```terminal
 observer.catalog_product_save_after
 observer.customer_login
+```
+
+## Return event details
+
+The `events:info` command returns the payload of the specified event.
+
+### Usage
+
+`bin/magento events:info <event_code>`
+
+### Arguments
+
+`<event_code>` Required. Specifies the event to.
+
+### Example
+
+`bin/magento events:info <something>`
+
+### Response
+
+```json
+xyx
 ```
 
 ## Create a registration

--- a/src/pages/events/commands.md
+++ b/src/pages/events/commands.md
@@ -12,12 +12,11 @@ Adobe Commerce provides the following commands to configure and process events:
 *  Enable integration between Commerce and Adobe I/O events
    *  [events:create-event-provider](#create-an-event-provider)  
 
-*  Manage event subscriptions
+*  Manage events subscriptions
    *  [events:subscribe](#subscribe-to-a-commerce-event)
    *  [events:metadata:populate](#create-event-metadata-in-adobe-io)
    *  [events:unsubscribe](#unsubscribe-from-a-commerce-event)
    *  [events:list](#list-subscribed-commerce-events)
-   *  [events:info](#return-event-details)
 
 *  Manage registrations
    *  [events:registration:create](#create-a-registration)
@@ -166,28 +165,6 @@ bin/magento events:list
 ```terminal
 observer.catalog_product_save_after
 observer.customer_login
-```
-
-## Return event details
-
-The `events:info` command returns the payload of the specified event.
-
-### Usage
-
-`bin/magento events:info <event_code>`
-
-### Arguments
-
-`<event_code>` Required. Specifies the event to.
-
-### Example
-
-`bin/magento events:info <something>`
-
-### Response
-
-```json
-xyx
 ```
 
 ## Create a registration

--- a/src/pages/events/commands.md
+++ b/src/pages/events/commands.md
@@ -18,11 +18,6 @@ Adobe Commerce provides the following commands to configure and process events:
    *  [events:unsubscribe](#unsubscribe-from-a-commerce-event)
    *  [events:list](#list-subscribed-commerce-events)
 
-*  Manage registrations
-   *  [events:registration:create](#create-a-registration)
-   *  [events:registration:delete](#delete-a-registration)
-   *  [events:registration:get-all](#get-registration-details)
-
 *  Generate a Commerce module
    *  [events:generate:module](#generate-a-commerce-module-based-on-a-list-of-subscribed-events)
 
@@ -165,72 +160,6 @@ bin/magento events:list
 ```terminal
 observer.catalog_product_save_after
 observer.customer_login
-```
-
-## Create a registration
-
-The `events:registration:create` command registers the merchant to Adobe Identity Management Services. You must configure the **Stores** > Configuration > **Adobe Services** > **Adobe I/O Events** > **Commerce Events** > **Merchant ID** and **Environment ID** fields before running this command.
-
-### Usage
-
-`bin/magento events:registration:create`
-
-### Example
-
-```bash
-bin/magento events:registration:create
-```
-
-### Response
-
-```terminal
-Registration created
-```
-
-## Delete a registration
-
-The `events:registration:delete` command deletes the specified registrant from the IMS organization.
-
-### Usage
-
-`bin/magento events:registration:delete <registration-id>`
-
-### Arguments
-
-`<registration-id>` Required. The ID assigned to the registration. Use the `events:registration:get-all` command to retrieve the ID.
-
-### Example
-
-```bash
-bin/magento events:registration:delete e037f0de-3489-49c7-9366-df86491072b4
-```
-
-### Response
-
-```terminal
-Registration was deleted
-```
-
-## Get registration details
-
-The `events:registration:get-all` command returns details about a registrant. The response includes the registration ID, merchant ID, environment ID, IMS organization ID, and instance ID.
-
-### Usage
-
-`bin/magento events:registration:get-all`
-
-### Example
-
-```bash
-bin/magento events:registration:get-all
-```
-
-### Response
-
-```terminal
-+--------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| e037f0de-3489-49c7-9366-df86491072b4 | {"id":"e037f0de-3489-49c7-9366-df86491072b4","merchant_id":"extension-docs","environment_id":"extension-docs","ims_org_id":"12345678901234567890ABCD@AdobeOrg","instance_id":"extensibility-docs2","event_provider_metadata":"3rd_party_custom_events"} |
-+--------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ```
 
 ## Create event metadata in Adobe I/O

--- a/src/pages/events/configure-commerce.md
+++ b/src/pages/events/configure-commerce.md
@@ -165,12 +165,6 @@ You cannot create an event provider until you have configured and saved a privat
 
 1. Click **Save Config**.
 
-1. Register your instance with Adobe Identity Management Services by running the following command:
-
-   ```bash
-   bin/magento events:registration:create
-   ```
-
 ## Subscribe and register events
 
 You must define which Commerce events to subscribe to, then register them in the project.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR removes all references to the `events:registration:create/delete/get-all` commands, per CEXT-1137

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
