### PR TITLE
COMDOX-588: Standardized README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,37 @@
-# Commerce Extensibility
+# Adobe I/O Events for Adobe Commerce Documentation
 
-TODO: Update description
+Welcome! This site contains the latest Adobe I/O Events for Adobe Commerce developer documentation for ongoing releases.
+
+## Local development
+
+This is a [Gatsby](https://www.gatsbyjs.com/) project that uses the [Adobe I/O Theme](https://github.com/adobe/aio-theme).
+
+To build the site locally:
+
+1. Clone this repo.
+1. Install project dependencies.
+
+   ```bash
+   yarn install
+   ```
+
+1. Launch the project in development mode.
+
+   ```bash
+   yarn dev
+   ```
+
+## Resources
+
+See the following resources to learn more about using the theme:
+
+- [Arranging content structure](https://github.com/adobe/aio-theme#content-structure)
+- [Linking to pages](https://github.com/adobe/aio-theme#links)
+- [Using assets](https://github.com/adobe/aio-theme#assets)
+- [Configuring global navigation](https://github.com/adobe/aio-theme#global-navigation)
+- [Configuring side navigation](https://github.com/adobe/aio-theme#side-navigation)
+- [Using content blocks](https://github.com/adobe/aio-theme#jsx-blocks)
+- [Writing enhanced Markdown](https://github.com/adobe/aio-theme#writing-enhanced-markdown)
+- [Deploying the site](https://github.com/adobe/aio-theme#deploy-to-azure-storage-static-websites) _(Adobe employees only)_
+
+If you have questions, open an issue and ask us. We look forward to hearing from you!


### PR DESCRIPTION
This pull request (PR) standardizes the README using the [magento/devdocs](https://github.com/magento/devdocs/blob/master/README.md?plain=1) repo as a baseline. The goal is to have a standard README that can be used across all [`commerce-*`](https://github.com/topics/adobe-commerce-devsite) devsite repos and add repo-specific info if necessary (e.g., generating API reference, rendering templates).

This README differs slightly from other `commerce-*` repos because the docs are for Adobe Commerce only.