### PR TITLE
Add autodeployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,133 @@
+---
+name: Production deployment
+on:
+  push:
+    branches:
+      - main
+jobs:
+  set-state:
+    runs-on: ubuntu-latest
+    outputs:
+      path_prefix: ${{ steps.get_path_prefix.outputs.path_prefix }}
+      branch_short_ref: ${{ steps.get_branch.outputs.branch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get pathPrefix
+        uses: actions/github-script@v6
+        id: get_path_prefix
+        with:
+          script: |
+            const script = require('./.github/scripts/get-path-prefix.js');
+            script({ core });
+          result-encoding: string
+      - name: Get branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]${GITHUB_REF#refs/heads/}"
+        id: get_branch
+
+  echo-state:
+    needs: [set-state]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Repository org - ${{ github.event.repository.owner.login }}"
+      - run: echo "Repository name - ${{ github.event.repository.name }}"
+      - run: echo "Repository branch - ${{ needs.set-state.outputs.branch_short_ref }}"
+      - run: echo "Path prefix - ${{ needs.set-state.outputs.path_prefix }}"
+
+  pre-build:
+    needs: [set-state]
+    runs-on: ubuntu-latest
+    steps:
+      - name: check prod azure connection string
+        if: env.AIO_AZURE_PROD_CONNECTION_STRING == null
+        run: |
+          echo "::error::Please set the Azure Blob Storage connection string as AIO_AZURE_PROD_CONNECTION_STRING in Github Secrets"
+          exit 1
+        env:
+          AIO_AZURE_PROD_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_CONNECTION_STRING }}
+
+  build:
+    defaults:
+      run:
+        shell: bash
+    needs: [set-state, pre-build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node v16 for Yarn v3
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.15.0' # Current LTS version
+
+      - name: Enable Corepack for Yarn v3
+        run: corepack enable
+
+      - name: Install Yarn v3
+        uses: borales/actions-yarn@v3
+        with:
+          cmd: set version stable
+
+      - name: Install Dependencies
+        uses: borales/actions-yarn@v3
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
+        with:
+          cmd: install
+
+      - name: Gatsby Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            public
+            .cache
+          key: ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-${{ github.run_id }}
+          restore-keys: |
+            ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-
+
+      - name: Build site
+        uses: borales/actions-yarn@v3
+        with:
+          cmd: build
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
+          PREFIX_PATHS: true # equivalent to --prefix-paths flag for 'gatsby build'
+          PATH_PREFIX: ${{ needs.set-state.outputs.path_prefix }}
+          GATSBY_ADOBE_LAUNCH_SRC: ${{ secrets.AIO_ADOBE_LAUNCH_PROD_SRC }}
+          GATSBY_ADDITIONAL_ADOBE_ANALYTICS_ACCOUNTS: ${{ secrets.AIO_REPORT_SUITE_PROD }}
+          GATSBY_ADOBE_ANALYTICS_ENV: 'production'
+          REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_OWNER: ${{ github.event.repository.owner.login }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          REPO_BRANCH: ${{ needs.set-state.outputs.branch_short_ref }}
+          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          GOOGLE_DOCS_TOKEN: ${{ secrets.GOOGLE_DOCS_TOKEN }}
+          GOOGLE_DOCS_FOLDER_ID: ${{ secrets.GOOGLE_DOCS_FOLDER_ID }}
+          GATSBY_IMS_SRC: ${{ secrets.AIO_IMS_PROD_SRC }}
+          GATSBY_IMS_CONFIG: ${{ secrets.AIO_IMS_PROD_CONFIG }}
+          GATSBY_ALGOLIA_APPLICATION_ID: ${{ secrets.AIO_ALGOLIA_APPLICATION_ID }}
+          GATSBY_ALGOLIA_SEARCH_API_KEY: ${{ secrets.AIO_ALGOLIA_SEARCH_API_KEY }}
+          ALGOLIA_INDEXATION_MODE: skip
+          GATSBY_ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME || github.event.repository.name }}
+          GATSBY_FEDS_PRIVACY_ID: ${{ secrets.AIO_FEDS_PRIVACY_ID }}
+          GATSBY_SITE_DOMAIN_URL: https://developer.adobe.com
+      - name: Deploy
+        uses: icaraps/static-website-deploy@master
+        with:
+          enabled-static-website: 'true'
+          source: 'public'
+          target: ${{ needs.set-state.outputs.path_prefix }}
+          connection-string: ${{ secrets.AIO_AZURE_PROD_CONNECTION_STRING }}
+          remove-existing-files: 'true'
+      - name: Delay purge
+        run: sleep 60s
+        shell: bash
+      - name: Purge Fastly Cache
+        uses: icaraps/gatsby-fastly-purge-action@master
+        with:
+          fastly-token: ${{ secrets.AIO_FASTLY_TOKEN }}
+          fastly-url: '${{ secrets.AIO_FASTLY_PROD_URL }}${{ needs.set-state.outputs.path_prefix }}'

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -1,12 +1,8 @@
 ---
-name: Deployment
+name: Staging deployment
 on:
   workflow_dispatch:
     inputs:
-      env:
-        description: 'Deploy to (dev|prod|dev prod)'
-        required: true
-        default: 'dev'
       clean:
         description: 'Clean cache (yes|no)'
         required: true
@@ -19,8 +15,6 @@ jobs:
   set-state:
     runs-on: ubuntu-latest
     outputs:
-      deploy_prod: ${{ contains(github.event.inputs.env, 'prod') }}
-      deploy_dev: ${{ contains(github.event.inputs.env, 'dev') }}
       clean_cache: ${{ contains(github.event.inputs.clean, 'yes') }}
       path_prefix: ${{ steps.get_path_prefix.outputs.path_prefix }}
       branch_short_ref: ${{ steps.get_branch.outputs.branch }}
@@ -46,8 +40,6 @@ jobs:
     needs: [set-state]
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Deploy to dev - ${{ needs.set-state.outputs.deploy_dev }}"
-      - run: echo "Deploy to prod - ${{ needs.set-state.outputs.deploy_prod }}"
       - run: echo "Clean cache - ${{ needs.set-state.outputs.clean_cache }}"
       - run: echo "Repository org - ${{ github.event.repository.owner.login }}"
       - run: echo "Repository name - ${{ github.event.repository.name }}"
@@ -55,10 +47,9 @@ jobs:
       - run: echo "Path prefix - ${{ needs.set-state.outputs.path_prefix }}"
       - run: echo "Exclude subfolder - ${{ needs.set-state.outputs.exclude_subfolder }}"
 
-  pre-build-dev:
+  pre-build:
     needs: [set-state]
     runs-on: ubuntu-latest
-    if: needs.set-state.outputs.deploy_dev == 'true'
     steps:
       - name: check dev azure connection string
         if: env.AIO_AZURE_DEV_CONNECTION_STRING == null
@@ -68,11 +59,11 @@ jobs:
         env:
           AIO_AZURE_DEV_CONNECTION_STRING: ${{ secrets.AIO_AZURE_DEV_CONNECTION_STRING }}
 
-  build-dev:
+  build:
     defaults:
       run:
         shell: bash
-    needs: [set-state, pre-build-dev]
+    needs: [set-state, pre-build]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -119,6 +110,7 @@ jobs:
         with:
           cmd: build
         env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
           PREFIX_PATHS: true # equivalent to --prefix-paths flag for 'gatsby build'
           PATH_PREFIX: ${{ needs.set-state.outputs.path_prefix }}
           GATSBY_ADOBE_LAUNCH_SRC: ${{ secrets.AIO_ADOBE_LAUNCH_DEV_SRC }}
@@ -136,11 +128,10 @@ jobs:
           GATSBY_IMS_CONFIG: ${{ secrets.AIO_IMS_DEV_CONFIG }}
           GATSBY_ALGOLIA_APPLICATION_ID: ${{ secrets.AIO_ALGOLIA_APPLICATION_ID }}
           GATSBY_ALGOLIA_SEARCH_API_KEY: ${{ secrets.AIO_ALGOLIA_SEARCH_API_KEY }}
-          GATSBY_ALGOLIA_APP_ID: ${{ secrets.AIO_ALGOLIA_APP_ID }}
-          GATSBY_ALGOLIA_API_KEY: ${{ secrets.AIO_ALGOLIA_API_KEY }}
-          GATSBY_ALGOLIA_INDEX_ALL_SRC: ${{ secrets.AIO_ALGOLIA_INDEX_ALL_SRC }}
-          GATSBY_ALGOLIA_SEARCH_INDEX: ${{ secrets.AIO_ALGOLIA_SEARCH_INDEX }}
+          ALGOLIA_INDEXATION_MODE: skip
+          GATSBY_ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME || github.event.repository.name }}
           GATSBY_FEDS_PRIVACY_ID: ${{ secrets.AIO_FEDS_PRIVACY_ID }}
+          GATSBY_SITE_DOMAIN_URL: https://developer-stage.adobe.com
 
       - name: Deploy
         uses: icaraps/static-website-deploy@master
@@ -159,110 +150,3 @@ jobs:
         with:
           fastly-token: ${{ secrets.AIO_FASTLY_TOKEN }}
           fastly-url: '${{ secrets.AIO_FASTLY_DEV_URL}}${{ needs.set-state.outputs.path_prefix }}'
-
-  pre-build-production:
-    needs: [set-state]
-    runs-on: ubuntu-latest
-    if: needs.set-state.outputs.deploy_prod == 'true'
-    steps:
-      - name: check prod azure connection string
-        if: env.AIO_AZURE_PROD_CONNECTION_STRING == null
-        run: |
-          echo "::error::Please set the Azure Blob Storage connection string as AIO_AZURE_PROD_CONNECTION_STRING in Github Secrets"
-          exit 1
-        env:
-          AIO_AZURE_PROD_CONNECTION_STRING: ${{ secrets.AIO_AZURE_PROD_CONNECTION_STRING }}
-
-  build-production:
-    defaults:
-      run:
-        shell: bash
-    needs: [set-state, pre-build-production]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Node v16 for Yarn v3
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16.15.0' # Current LTS version
-
-      - name: Enable Corepack for Yarn v3
-        run: corepack enable
-
-      - name: Install Yarn v3
-        uses: borales/actions-yarn@v3
-        with:
-          cmd: set version stable
-
-      - name: Install Dependencies
-        uses: borales/actions-yarn@v3
-        env:
-          YARN_ENABLE_IMMUTABLE_INSTALLS: false
-        with:
-          cmd: install
-
-      - name: Gatsby Cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            public
-            .cache
-          key: ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-${{ github.run_id }}
-          restore-keys: |
-            ${{ needs.set-state.outputs.branch_short_ref }}-gatsby-cache-
-
-      - name: Clean Cache
-        if: needs.set-state.outputs.clean_cache == 'true'
-        uses: borales/actions-yarn@v3
-        with:
-          cmd: clean
-
-      - name: Build site
-        uses: borales/actions-yarn@v3
-        with:
-          cmd: build
-        env:
-          PREFIX_PATHS: true # equivalent to --prefix-paths flag for 'gatsby build'
-          PATH_PREFIX: ${{ needs.set-state.outputs.path_prefix }}
-          GATSBY_ADOBE_LAUNCH_SRC: ${{ secrets.AIO_ADOBE_LAUNCH_PROD_SRC }}
-          GATSBY_ADDITIONAL_ADOBE_ANALYTICS_ACCOUNTS: ${{ secrets.AIO_REPORT_SUITE_PROD }}
-          GATSBY_ADOBE_ANALYTICS_ENV: 'production'
-          REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_OWNER: ${{ github.event.repository.owner.login }}
-          REPO_NAME: ${{ github.event.repository.name }}
-          REPO_BRANCH: ${{ needs.set-state.outputs.branch_short_ref }}
-          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-          GOOGLE_DOCS_TOKEN: ${{ secrets.GOOGLE_DOCS_TOKEN }}
-          GOOGLE_DOCS_FOLDER_ID: ${{ secrets.GOOGLE_DOCS_FOLDER_ID }}
-          GATSBY_IMS_SRC: ${{ secrets.AIO_IMS_PROD_SRC }}
-          GATSBY_IMS_CONFIG: ${{ secrets.AIO_IMS_PROD_CONFIG }}
-          GATSBY_ALGOLIA_APPLICATION_ID: ${{ secrets.AIO_ALGOLIA_APPLICATION_ID }}
-          GATSBY_ALGOLIA_SEARCH_API_KEY: ${{ secrets.AIO_ALGOLIA_SEARCH_API_KEY }}
-          GATSBY_ALGOLIA_APP_ID: ${{ secrets.AIO_ALGOLIA_APP_ID }}
-          GATSBY_ALGOLIA_API_KEY: ${{ secrets.AIO_ALGOLIA_API_KEY }}
-          ALGOLIA_WRITE_API_KEY: ${{ secrets.AIO_ALGOLIA_WRITE_API_KEY }}
-          ALGOLIA_INDEXATION_MODE: ${{ secrets.AIO_ALGOLIA_INDEXATION_MODE }}
-          ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME || github.event.repository.name }}
-          GATSBY_ALGOLIA_INDEX_ALL_SRC: ${{ secrets.AIO_ALGOLIA_INDEX_ALL_SRC }}
-          GATSBY_ALGOLIA_SEARCH_INDEX: ${{ secrets.AIO_ALGOLIA_SEARCH_INDEX }}
-          GATSBY_FEDS_PRIVACY_ID: ${{ secrets.AIO_FEDS_PRIVACY_ID }}
-      - name: Deploy
-        uses: icaraps/static-website-deploy@master
-        with:
-          enabled-static-website: 'true'
-          source: 'public'
-          target: ${{ needs.set-state.outputs.path_prefix }}
-          connection-string: ${{ secrets.AIO_AZURE_PROD_CONNECTION_STRING }}
-          remove-existing-files: 'true'
-          exclude-subfolder: ${{ needs.set-state.outputs.exclude_subfolder }}
-      - name: Delay purge
-        run: sleep 60s
-        shell: bash
-      - name: Purge Fastly Cache
-        uses: icaraps/gatsby-fastly-purge-action@master
-        with:
-          fastly-token: ${{ secrets.AIO_FASTLY_TOKEN }}
-          fastly-url: '${{ secrets.AIO_FASTLY_PROD_URL }}${{ needs.set-state.outputs.path_prefix }}'


### PR DESCRIPTION
## Purpose of this pull request

This pull request splits the deploy workflow into two workflows: _staging_ and _publish_.
The _staging_ workflow will run similar to how the deploy workflow was run with only difference that you won't choose an environment (dev or prod).
The _publish_ workflow will run automatically with every push to the main branch. No cache cleaning or folder exclusion. Indexing is set to skip to reduce the runtime.

## Affected pages

none

## Additional information

Internal ref: COMDOX-292

I couldn't apply reusable workflows within the repo. Every job is a bit different. It seems to be possible to reuse the workflows in other repos though.