### PR TITLE
Add 244 support

### DIFF
--- a/src/pages/get-started/installation.md
+++ b/src/pages/get-started/installation.md
@@ -5,7 +5,7 @@ description: Learn how to install the Commerce modules needed for Adobe I/O Even
 
 # Install Adobe I/O Events for Adobe Commerce
 
-Adobe I/O Events for Adobe Commerce requires Adobe Commerce 2.4.5+.
+Adobe I/O Events for Adobe Commerce requires Adobe Commerce 2.4.4+.
 
 Magento Open Source is not supported.
 
@@ -15,13 +15,13 @@ After you have created an [App Builder project](./project-setup.md), you must in
 
 The following steps apply to both Adobe Commerce on cloud infrastructure and on-premises installations. Cloud customers must perform additional steps to configure the `ece-tools` package.
 
-1. If you are running Commerce 2.4.5, use the following command to load the eventing modules:
+1. If you are running Commerce 2.4.4 or 2.4.5, use the following command to load the eventing modules:
 
    ```bash
    composer require magento/commerce-eventing=^1.0 --no-update
    ```
 
-   Commerce 2.4.6 beta and later loads these modules automatically.
+   Commerce 2.4.6 and later loads these modules automatically.
 
 1. Update the project dependencies.
 

--- a/src/pages/get-started/installation.md
+++ b/src/pages/get-started/installation.md
@@ -5,7 +5,7 @@ description: Learn how to install the Commerce modules needed for Adobe I/O Even
 
 # Install Adobe I/O Events for Adobe Commerce
 
-Adobe I/O Events for Adobe Commerce requires Adobe Commerce 2.4.4+.
+Adobe I/O Events for Adobe Commerce requires Adobe Commerce 2.4.4 or higher.
 
 Magento Open Source is not supported.
 

--- a/src/pages/get-started/release-notes.md
+++ b/src/pages/get-started/release-notes.md
@@ -15,7 +15,7 @@ See [Update Adobe I/O Events for Adobe Commerce](./installation.md#update-adobe-
 
 May 25, 2023
 
-### Enchancements
+### Enhancements
 
 *  The Adobe I/O Service Account (JWT) credentials have been deprecated in favor of the OAuth Server-to-Server credentials. Adobe Commerce Eventing now supports the OAuth Server-to-Server crendentials. The [Create an App Builder project](project-setup.md) and [Configure Adobe Commerce](configure-commerce.md) topics have been updated to include instructions for setting up OAuth authentication. See the [_Adobe Developer Authentication Guide_](https://developer.adobe.com/developer-console/docs/guides/authentication/) for details about OAuth support.
 
@@ -29,7 +29,7 @@ May 25, 2023
 
 April 20, 2023
 
-### Enchancements
+### Enhancements
 
 *  Added support for delivering events using message queues. Previously, all events were delivered by cron, which could delay delivery by up to a minute. Use the `bin/magento events:subscribe --priority` command to register the event as requiring expedited delivery. See [Configure Adobe Commerce](./configure-commerce.md#check-cron-and-message-queue-configuration) for information about configuring the message queues.
 
@@ -75,13 +75,12 @@ January 17, 2023
 
 Adobe Commerce for Cloud
 
-*  2.4.5+, 2.4.6 beta
+*  2.4.4+
 *  `ece-tools` 2002.1.13+
 
 Adobe Commerce (on-premises)
 
-*  2.4.5+
-*  2.4.6 beta
+*  2.4.4+
 
 ### Known issues
 

--- a/src/pages/get-started/release-notes.md
+++ b/src/pages/get-started/release-notes.md
@@ -15,7 +15,20 @@ See [Update Adobe I/O Events for Adobe Commerce](./installation.md#update-adobe-
 
 May 25, 2023
 
+### Compatibility
+
+Adobe Commerce for Cloud
+
+*  2.4.4+
+*  `ece-tools` 2002.1.13+
+
+Adobe Commerce (on-premises)
+
+*  2.4.4+
+
 ### Enhancements
+
+*  I/O Events for Adobe Commerce now supports 2.4.4.
 
 *  The Adobe I/O Service Account (JWT) credentials have been deprecated in favor of the OAuth Server-to-Server credentials. Adobe Commerce Eventing now supports the OAuth Server-to-Server crendentials. The [Create an App Builder project](project-setup.md) and [Configure Adobe Commerce](configure-commerce.md) topics have been updated to include instructions for setting up OAuth authentication. See the [_Adobe Developer Authentication Guide_](https://developer.adobe.com/developer-console/docs/guides/authentication/) for details about OAuth support.
 
@@ -75,12 +88,12 @@ January 17, 2023
 
 Adobe Commerce for Cloud
 
-*  2.4.4+
+*  2.4.5+
 *  `ece-tools` 2002.1.13+
 
 Adobe Commerce (on-premises)
 
-*  2.4.4+
+*  2.4.5+
 
 ### Known issues
 

--- a/src/pages/get-started/release-notes.md
+++ b/src/pages/get-started/release-notes.md
@@ -19,12 +19,12 @@ May 25, 2023
 
 Adobe Commerce for Cloud
 
-*  2.4.4+
+*  2.4.4 and higher
 *  `ece-tools` 2002.1.13+
 
 Adobe Commerce (on-premises)
 
-*  2.4.4+
+*  2.4.4 and higher
 
 ### Enhancements
 
@@ -88,12 +88,12 @@ January 17, 2023
 
 Adobe Commerce for Cloud
 
-*  2.4.5+
+*  2.4.5 and higher
 *  `ece-tools` 2002.1.13+
 
 Adobe Commerce (on-premises)
 
-*  2.4.5+
+*  2.4.5 and higher
 
 ### Known issues
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the release notes and installation instructions to include support for Commerce 2.4.4.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-events/blob/main/.github/CONTRIBUTING.md) for more information.
-->
