### PR TITLE
Add events:provider:info command

### DIFF
--- a/src/pages/get-started/commands.md
+++ b/src/pages/get-started/commands.md
@@ -10,7 +10,8 @@ Adobe I/O Events allow you to receive notifications of real-time events taking p
 Adobe Commerce provides the following commands to configure and process events:
 
 *  Enable integration between Commerce and Adobe I/O events
-   *  [events:create-event-provider](#create-an-event-provider)  
+   *  [events:create-event-provider](#create-an-event-provider)
+   *  [events:provider:info](#get-details-about-a-configured-event-provider)
    *  [events:metadata:populate](#create-event-metadata-in-adobe-io)
 
 *  Manage event subscriptions
@@ -62,6 +63,29 @@ bin/magento events:create-event-provider --label "my_new_event_provider" --descr
 No event provider found, a new event provider will be created
 
 A new event provider has been created with ID <ID>.
+```
+
+## Get details about a configured event provider
+
+The `events:provider:info` command returns details about a configured event provider.
+
+### Usage
+
+`events:provider:info`
+
+### Example
+
+```bash
+bin/magento events:provider:info
+```
+
+### Response
+
+```terminal
+Configured event provider details:
+- id: abcdef12-e499-5a0a-a683-1234567890ab
+- label: test provider
+- description: testing local provider creation (Instance docs-stage-testing)
 ```
 
 ## Create event metadata in Adobe I/O


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the `events:provider:info` command.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-events/blob/main/.github/CONTRIBUTING.md) for more information.
-->
